### PR TITLE
feat: parseHook supports escaping

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'fs'
-import { Hook, ScanOptions, scanPath } from './core'
+import { Hook, ScanOptions, parseHook, scanPath } from './core'
 import type { Format } from 'esbuild'
 
 const pkg = require('../package.json')
@@ -225,15 +225,4 @@ Options:
     Alias: -h
 `.trim(),
   )
-}
-
-function parseHook(arg: string): Hook {
-  let match = arg.match(/#watch:(.*?)$/)
-  if (!match) return { command: arg }
-  let watch = match[1]
-  let command = arg.slice(0, arg.length - match[0].length)
-  return {
-    watchFiles: watch.split(','),
-    command,
-  }
 }

--- a/src/test/parse-hook.ts
+++ b/src/test/parse-hook.ts
@@ -1,0 +1,48 @@
+import { parseHook } from '../core';
+
+let hook = parseHook('command with spaces');
+
+if (hook.command !== 'command with spaces' || hook.watchFiles.length !== 0) {
+  throw new Error('Failed to parse hook');
+}
+
+hook = parseHook('command with spaces#watch:./src');
+
+if (
+  hook.command !== 'command with spaces' ||
+  hook.watchFiles.length !== 1 ||
+  hook.watchFiles[0] !== './src'
+) {
+  throw new Error('Failed to parse hook');
+}
+
+hook = parseHook('command with spaces\\#watch:./src');
+
+if (
+  hook.command !== 'command with spaces\\#watch:./src' ||
+  hook.watchFiles.length !== 0
+) {
+  throw new Error('Failed to parse hook');
+}
+
+hook = parseHook('command with spaces#watch:./file1.js,./file2.ts');
+
+if (
+  hook.command !== 'command with spaces' ||
+  hook.watchFiles.length !== 2 ||
+  hook.watchFiles[0] !== './file1.js' ||
+  hook.watchFiles[1] !== './file2.ts'
+) {
+  throw new Error('Failed to parse hook');
+}
+
+hook = parseHook('command with spaces\\#watch:./src#watch:./file1.js,./file2.ts');
+
+if (
+  hook.command !== 'command with spaces\\#watch:./src' ||
+  hook.watchFiles.length !== 2 ||
+  hook.watchFiles[0] !== './file1.js' ||
+  hook.watchFiles[1] !== './file2.ts'
+) {
+  throw new Error('Failed to parse hook');
+}


### PR DESCRIPTION
This PR includes the fix mentioned in #3, that you can add a `\` before watch to escape it.

Also added some tests in `src/test/parse-hook.ts`

https://github.com/arthurfiorette/live-tsc/blob/910d4111d573d4b7db63dbc5553620677ee0cda7/src/test/parse-hook.ts#L3-L48